### PR TITLE
multiple credentials in assertion

### DIFF
--- a/fido2.go
+++ b/fido2.go
@@ -643,8 +643,7 @@ func (d *Device) Assertion(
 	if cErr := C.fido_assert_set_clientdata_hash(cAssert, cBytes(clientDataHash), cLen(clientDataHash)); cErr != C.FIDO_OK {
 		return nil, errors.Wrapf(errFromCode(cErr), "failed to set client data hash")
 	}
-	for i := 0; i < len(credentialIDs); i++ {
-		credentialID := credentialIDs[i]
+	for _, credentialID := range credentialIDs {
 		if cErr := C.fido_assert_allow_cred(cAssert, cBytes(credentialID), cLen(credentialID)); cErr != C.FIDO_OK {
 			return nil, errors.Wrapf(errFromCode(cErr), "failed to set allowed credentials")
 		}

--- a/fido2.go
+++ b/fido2.go
@@ -643,12 +643,10 @@ func (d *Device) Assertion(
 	if cErr := C.fido_assert_set_clientdata_hash(cAssert, cBytes(clientDataHash), cLen(clientDataHash)); cErr != C.FIDO_OK {
 		return nil, errors.Wrapf(errFromCode(cErr), "failed to set client data hash")
 	}
-	if credentialIDs != nil {
-		for i := 0; i < len(credentialIDs); i++ {
-			credentialID := credentialIDs[i]
-			if cErr := C.fido_assert_allow_cred(cAssert, cBytes(credentialID), cLen(credentialID)); cErr != C.FIDO_OK {
-				return nil, errors.Wrapf(errFromCode(cErr), "failed to set allowed credentials")
-			}
+	for i := 0; i < len(credentialIDs); i++ {
+		credentialID := credentialIDs[i]
+		if cErr := C.fido_assert_allow_cred(cAssert, cBytes(credentialID), cLen(credentialID)); cErr != C.FIDO_OK {
+			return nil, errors.Wrapf(errFromCode(cErr), "failed to set allowed credentials")
 		}
 	}
 	if exts := extensionsInt(opts.Extensions); exts > 0 {

--- a/fido2.go
+++ b/fido2.go
@@ -617,7 +617,7 @@ type AssertionOpts struct {
 func (d *Device) Assertion(
 	rpID string,
 	clientDataHash []byte,
-	credentialID []byte,
+	credentialIDs [][]byte,
 	pin string,
 	opts *AssertionOpts) (*Assertion, error) {
 
@@ -643,9 +643,12 @@ func (d *Device) Assertion(
 	if cErr := C.fido_assert_set_clientdata_hash(cAssert, cBytes(clientDataHash), cLen(clientDataHash)); cErr != C.FIDO_OK {
 		return nil, errors.Wrapf(errFromCode(cErr), "failed to set client data hash")
 	}
-	if credentialID != nil {
-		if cErr := C.fido_assert_allow_cred(cAssert, cBytes(credentialID), cLen(credentialID)); cErr != C.FIDO_OK {
-			return nil, errors.Wrapf(errFromCode(cErr), "failed to set allowed credentials")
+	if credentialIDs != nil {
+		for i := 0; i < len(credentialIDs); i++ {
+			credentialID := credentialIDs[i]
+			if cErr := C.fido_assert_allow_cred(cAssert, cBytes(credentialID), cLen(credentialID)); cErr != C.FIDO_OK {
+				return nil, errors.Wrapf(errFromCode(cErr), "failed to set allowed credentials")
+			}
 		}
 	}
 	if exts := extensionsInt(opts.Extensions); exts > 0 {


### PR DESCRIPTION
The goal is to provide multiple credIDs into get_assertion function.
Useful when you have several MFA devices registered on your RP.

Although this change breaks API compat so it might be better to create a separate function. Wdyt @gabriel?