### PR TITLE
improve darwin paths for brew installed libraries

### DIFF
--- a/fido2_static.go
+++ b/fido2_static.go
@@ -1,7 +1,7 @@
 package libfido2
 
 /*
-#cgo darwin LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/Cellar/libfido2/1.5.0/lib/libfido2.a /usr/local/Cellar/openssl@1.1/1.1.1k/lib/libcrypto.a ${SRCDIR}/darwin/lib/libcbor.a
-#cgo darwin CFLAGS: -I/usr/local/Cellar/libfido2/1.5.0/include -I/usr/local/Cellar/openssl@1.1/1.1.1k/include
+#cgo darwin LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/lib/libfido2.a /usr/local/opt/openssl@1.1/lib/libcrypto.a ${SRCDIR}/darwin/lib/libcbor.a
+#cgo darwin CFLAGS: -I/usr/local/opt/libfido2/include -I/usr/local/opt/openssl@1.1/include
 */
 import "C"


### PR DESCRIPTION
This PR resolves https://github.com/keys-pub/go-libfido2/issues/29 by using more standard generic paths for libfido2 and openssl libraries on macOS.