### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,9 +13,9 @@ jobs:
           sudo apt update
           sudo apt install libfido2-dev
       - name: Install dependencies (macos)
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
         run: |
-          brew install libfido2 openssl@3
+          brew install libfido2
       - name: Install scoop (windows)        
         if: matrix.os == 'windows-latest'
         uses: MinoruSekine/setup-scoop@main

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies (macos)
         if: matrix.os == 'macos-latest'
         run: |
-          brew install libfido2
+          brew install libfido2 openssl@3
       - name: Install scoop (windows)        
         if: matrix.os == 'windows-latest'
         uses: MinoruSekine/setup-scoop@main
@@ -28,7 +28,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.20.x
+          go-version: 1.19.x
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,14 +4,12 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ["macos-latest", "windows-latest", "ubuntu-latest"]
+        os: ["macos-13", "macos-latest", "windows-latest", "ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install dependencies (ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt install software-properties-common
-          sudo apt-add-repository -y ppa:yubico/stable
           sudo apt update
           sudo apt install libfido2-dev
       - name: Install dependencies (macos)
@@ -30,7 +28,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.x
+          go-version: 1.20.x
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build


### PR DESCRIPTION
* ubuntu latest is now 22+ so we no longer need the yubico PPA
* newer go version
* add testing on macos-13 which is still in beta for github actions

https://github.com/tylerd-canva/go-libfido2/actions/runs/5397494093